### PR TITLE
Client specific alerts

### DIFF
--- a/background/countdownAndAlerts.js
+++ b/background/countdownAndAlerts.js
@@ -101,18 +101,37 @@ function updateBadge(currentlyActiveJobcodeId, seconds_remaining, userProfile) {
 
   // render badge according to user alert preferences
   const alerts = userProfile.preferences.alerts || [];
-  const badgeAlerts = alerts.filter((alert) => alert.type === "badge");
+  console.log("All alerts:");
+  console.log(alerts);
+
+  const badgeAlerts = alerts.filter((alert) => {
+    return (
+      alert.type === "badge" &&
+      (alert.jobcode_ids.length === 0 ||
+        alert.jobcode_ids.includes(currentlyActiveJobcodeId))
+    );
+  });
+
+  console.log("badgeAlerts:");
+  console.log(badgeAlerts);
 
   // find the lowest alert time in seconds_remaining that is greater than the current remaining seconds_remaining
   const nextAlert = badgeAlerts
     .filter((alert) => alert.time_in_seconds >= seconds_remaining)
     .sort((a, b) => a.time_in_seconds - b.time_in_seconds)[0];
 
+  console.log("nextAlert:");
+  console.log(nextAlert);
+
   // if there are no alerts, then set the badge to the default colour
   if (!nextAlert) {
+    console.log("no next alert found, setting badge to default colour");
+
     const defaultBadgeColour = seconds_remaining > 0 ? "#00AA00" : "#FF0000"; // green if > 0, red if <= 0
     chrome.action.setBadgeBackgroundColor({ color: defaultBadgeColour });
   } else {
+    console.log("next alert found, setting badge to alert colour");
+
     // otherwise, set the badge to the alert colour
     const alertColour = nextAlert.asset_reference;
     chrome.action.setBadgeBackgroundColor({ color: alertColour });

--- a/background/countdownAndAlerts.js
+++ b/background/countdownAndAlerts.js
@@ -212,11 +212,14 @@ function checkForChromeNotifcationAlerts(
   const alerts = userProfile.preferences.alerts || [];
 
   // Check for notification alerts
-  const notificationAlert = alerts.find(
-    (alert) =>
-      alert.type === "notification" &&
-      alert.time_in_seconds === seconds_remaining
-  );
+  const notificationAlert = alerts.find((alert) => {
+    const isNotificationType = alert.type === "notification";
+    const isAtRightTime = alert.time_in_seconds === seconds_remaining;
+    const appliesToActiveJobcode =
+      alert.jobcode_ids.length === 0 ||
+      alert.jobcode_ids.includes(currentlyActiveJobcodeId);
+    return isNotificationType && isAtRightTime && appliesToActiveJobcode;
+  });
 
   // If a notification alert is found, create the notification
   if (notificationAlert) {

--- a/background/countdownAndAlerts.js
+++ b/background/countdownAndAlerts.js
@@ -14,7 +14,11 @@ let hasNotificationPermission = false;
  *                                      If null, displays infinity symbol.
  * @returns {void}
  */
-async function startBackgroundCountdown(initialSeconds, userProfile) {
+async function startBackgroundCountdown(
+  currentlyActiveJobcodeId,
+  initialSeconds,
+  userProfile
+) {
   // Clear any existing interval
   if (backgroundCountdownReference) {
     clearInterval(backgroundCountdownReference);

--- a/background/pollingScript.js
+++ b/background/pollingScript.js
@@ -61,10 +61,10 @@ async function pollForActivity() {
   if (onTheClock) {
     // calculate the remaining seconds
     const shiftSeconds = currentTotalsResponse.shift_seconds;
-    const jobcodeId = currentTotalsResponse.jobcode_id;
+    const currentlyActiveJobcodeId = currentTotalsResponse.jobcode_id;
     const jobcodeDetails = await getJobcodeFromStorage(
       currentUserId,
-      jobcodeId
+      currentlyActiveJobcodeId
     );
     const secondsAssigned = jobcodeDetails.seconds_assigned ?? null;
     const secondsCompletedThisMonth =
@@ -76,7 +76,11 @@ async function pollForActivity() {
         : secondsAssigned - secondsCompletedThisMonth - shiftSeconds;
 
     // Start or update the badge countdown
-    startBackgroundCountdown(remainingSeconds, currentUserProfile);
+    startBackgroundCountdown(
+      currentlyActiveJobcodeId,
+      remainingSeconds,
+      currentUserProfile
+    );
 
     // Notify the popup about the timer state
     try {

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -43,10 +43,10 @@ export async function addNewAlert(userProfile) {
     return;
   }
 
-  // Parse sound selection to determine type and asset reference
-  let alertTypeToUse = newAlertType;
+  // Parse the dropdown selection to determine fields to store for the new alert: type, asset_reference, display_name
+  let newAlertTypeToUse = newAlertType;
   let assetReference = "";
-  let displayName = "";
+  let displayName = ""; // only relevant for sounds
 
   if (newAlertType === "badge") {
     assetReference = newAlertColor;
@@ -54,13 +54,13 @@ export async function addNewAlert(userProfile) {
     // Parse the sound selection to determine if it's default or custom
     const soundParts = newAlertSound.split(":");
     if (soundParts[0] === "default") {
-      alertTypeToUse = "sound_default";
+      newAlertTypeToUse = "sound_default";
       assetReference = soundParts[1]; // filename
       displayName = soundParts[1]
         .replace(/_/g, " ")
         .replace(/\b\w/g, (l) => l.toUpperCase());
     } else if (soundParts[0] === "custom") {
-      alertTypeToUse = "sound_custom";
+      newAlertTypeToUse = "sound_custom";
       assetReference = soundParts[1]; // IndexedDB ID
       // Get display name from the custom sound data
       try {
@@ -74,18 +74,21 @@ export async function addNewAlert(userProfile) {
     }
   }
 
-  // Create jobcodeIds array - empty for "All clients", or array with selected ID
-  const jobcodeIds = newAlertSelectedClient ? [newAlertSelectedClient] : [];
+  // We make this an array in case we want to support multiple clients per alert in future
+  const newAlertJobcodeIds = newAlertSelectedClient
+    ? [newAlertSelectedClient]
+    : [];
 
   const newAlert = {
-    type: alertTypeToUse,
+    type: newAlertTypeToUse,
     time_in_seconds: newAlertTimeInSeconds,
     asset_reference: assetReference,
-    jobcode_ids: jobcodeIds,
+    jobcode_ids: newAlertJobcodeIds,
   };
 
-  // Add display_name for sound alerts
-  if (alertTypeToUse.startsWith("sound")) {
+  // We store a display_name only for sound alerts to show in the UI because
+  // the uploaded sound id contains non-user-friendly info (e.g. IDs) in order to make each upload unique
+  if (newAlertTypeToUse.startsWith("sound")) {
     newAlert.display_name = displayName;
   }
 

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -9,9 +9,9 @@ export async function addNewAlert(userProfile) {
   const newAlerSeconds =
     parseInt(document.getElementById("alert-seconds").value) || 0;
   const newAlertType = document.getElementById("alert-type").value;
-  const color = document.getElementById("alert-color").value;
-  const sound = document.getElementById("alert-sound").value;
-  const selectedClient = document.getElementById("alert-client").value;
+  const newAlertColor = document.getElementById("alert-color").value;
+  const newAlertSound = document.getElementById("alert-sound").value;
+  const newAlertSelectedClient = document.getElementById("alert-client").value;
 
   const newAlertTimeInSeconds = convertToSeconds(
     newAlertHours,
@@ -36,7 +36,7 @@ export async function addNewAlert(userProfile) {
     userProfile.preferences.alerts,
     newAlertType,
     newAlertTimeInSeconds,
-    selectedClient
+    newAlertSelectedClient
   );
   if (conflictMessage) {
     alert(conflictMessage);
@@ -49,10 +49,10 @@ export async function addNewAlert(userProfile) {
   let displayName = "";
 
   if (newAlertType === "badge") {
-    assetReference = color;
+    assetReference = newAlertColor;
   } else if (newAlertType === "sound") {
     // Parse the sound selection to determine if it's default or custom
-    const soundParts = sound.split(":");
+    const soundParts = newAlertSound.split(":");
     if (soundParts[0] === "default") {
       alertTypeToUse = "sound_default";
       assetReference = soundParts[1]; // filename
@@ -75,7 +75,7 @@ export async function addNewAlert(userProfile) {
   }
 
   // Create jobcodeIds array - empty for "All clients", or array with selected ID
-  const jobcodeIds = selectedClient ? [selectedClient] : [];
+  const jobcodeIds = newAlertSelectedClient ? [newAlertSelectedClient] : [];
 
   const newAlert = {
     type: alertTypeToUse,
@@ -489,18 +489,18 @@ function alertTypesMatch(storedAlertType, formAlertType) {
  * @param {Array} alerts - Array of existing alerts
  * @param {string} newAlertType - The form alert type (badge, sound, notification)
  * @param {number} newAlertTimeInSeconds - The alert time in seconds
- * @param {string} selectedClient - The selected client ID (empty string for "All clients")
+ * @param {string} newAlertSelectedClient - The selected client ID (empty string for "All clients")
  * @returns {string|null} - Error message if conflict exists, null if no conflict
  */
 function checkForAlertConflicts(
   alerts,
   newAlertType,
   newAlertTimeInSeconds,
-  selectedClient
+  newAlertSelectedClient
 ) {
   if (!alerts) return null;
 
-  const isNewAlertForAllClients = !selectedClient;
+  const isNewAlertForAllClients = !newAlertSelectedClient;
 
   // Check if there's already an "all clients" alert with same type and time
   const existingAllClientsAlert = alerts.find(

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -362,6 +362,45 @@ async function getCustomSounds() {
   }
 }
 
+/**
+ * Populates the client selector dropdown with all available jobcodes
+ * @param {Object} userProfile - The user profile containing jobcodes
+ */
+export function populateClientSelector(userProfile) {
+  const clientSelector = document.getElementById("alert-client");
+  if (!clientSelector) return;
+
+  // Clear existing options except the default "All clients"
+  clientSelector.innerHTML = '<option value="">All clients</option>';
+
+  try {
+    let jobcodes = Object.values(userProfile.jobcodes) || [];
+    
+    // Filter out jobcodes with children as these cannot have timesheets assigned
+    jobcodes = jobcodes.filter((jobcode) => !jobcode.has_children);
+    
+    // Sort jobcodes by their full name (parent_path_name + name)
+    jobcodes.sort((a, b) => {
+      const nameA = (a.parent_path_name || '') + a.name;
+      const nameB = (b.parent_path_name || '') + b.name;
+      return nameA.localeCompare(nameB);
+    });
+    
+    // Add each jobcode as an option
+    jobcodes.forEach((jobcode) => {
+      const option = document.createElement("option");
+      option.value = jobcode.id;
+      option.textContent = jobcode.parent_path_name 
+        ? jobcode.parent_path_name + jobcode.name
+        : jobcode.name;
+      clientSelector.appendChild(option);
+    });
+    
+  } catch (error) {
+    console.error("Error populating client selector:", error);
+  }
+}
+
 export function initializeAlertTypeSelector() {
   const alertTypeSelect = document.getElementById("alert-type");
   const colorPickerContainer = document.getElementById(

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -5,7 +5,7 @@ export async function addNewAlert(userProfile) {
   const hours = parseInt(document.getElementById("alert-hours").value) || 0;
   const minutes = parseInt(document.getElementById("alert-minutes").value) || 0;
   const seconds = parseInt(document.getElementById("alert-seconds").value) || 0;
-  const alertType = document.getElementById("alert-type").value;
+  const newAlertType = document.getElementById("alert-type").value;
   const color = document.getElementById("alert-color").value;
   const sound = document.getElementById("alert-sound").value;
   const selectedClient = document.getElementById("alert-client").value;
@@ -27,7 +27,7 @@ export async function addNewAlert(userProfile) {
   // Check for conflicting alerts with new client-aware logic
   const conflictMessage = checkForAlertConflicts(
     userProfile.preferences.alerts,
-    alertType,
+    newAlertType,
     timeInSeconds,
     selectedClient
   );
@@ -37,13 +37,13 @@ export async function addNewAlert(userProfile) {
   }
 
   // Parse sound selection to determine type and asset reference
-  let alertTypeToUse = alertType;
+  let alertTypeToUse = newAlertType;
   let assetReference = "";
   let displayName = "";
 
-  if (alertType === "badge") {
+  if (newAlertType === "badge") {
     assetReference = color;
-  } else if (alertType === "sound") {
+  } else if (newAlertType === "sound") {
     // Parse the sound selection to determine if it's default or custom
     const soundParts = sound.split(":");
     if (soundParts[0] === "default") {
@@ -480,14 +480,14 @@ function alertTypesMatch(storedAlertType, formAlertType) {
 /**
  * Checks for conflicting alerts with client-aware logic
  * @param {Array} alerts - Array of existing alerts
- * @param {string} alertType - The form alert type (badge, sound, notification)
+ * @param {string} newAlertType - The form alert type (badge, sound, notification)
  * @param {number} timeInSeconds - The alert time in seconds
  * @param {string} selectedClient - The selected client ID (empty string for "All clients")
  * @returns {string|null} - Error message if conflict exists, null if no conflict
  */
 function checkForAlertConflicts(
   alerts,
-  alertType,
+  newAlertType,
   timeInSeconds,
   selectedClient
 ) {
@@ -498,7 +498,7 @@ function checkForAlertConflicts(
   // Check if there's already an "all clients" alert with same type and time
   const existingAllClientsAlert = alerts.find(
     (alert) =>
-      alertTypesMatch(alert.type, alertType) &&
+      alertTypesMatch(alert.type, newAlertType) &&
       alert.time_in_seconds === timeInSeconds &&
       (!alert.jobcode_ids || alert.jobcode_ids.length === 0)
   );
@@ -511,7 +511,7 @@ function checkForAlertConflicts(
   if (!isNewAlertForAllClients) {
     const clashingAlert = alerts.find(
       (alert) =>
-        alertTypesMatch(alert.type, alertType) &&
+        alertTypesMatch(alert.type, newAlertType) &&
         alert.time_in_seconds === timeInSeconds
     );
 
@@ -524,7 +524,7 @@ function checkForAlertConflicts(
   if (isNewAlertForAllClients) {
     const existingClientSpecificAlert = alerts.find(
       (alert) =>
-        alertTypesMatch(alert.type, alertType) &&
+        alertTypesMatch(alert.type, newAlertType) &&
         alert.time_in_seconds === timeInSeconds
     );
 

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -2,22 +2,29 @@ import { overwriteUserProfileInStorage } from "/popup/user.js";
 
 // Function to add a new alert
 export async function addNewAlert(userProfile) {
-  const hours = parseInt(document.getElementById("alert-hours").value) || 0;
-  const minutes = parseInt(document.getElementById("alert-minutes").value) || 0;
-  const seconds = parseInt(document.getElementById("alert-seconds").value) || 0;
+  const newAlertHours =
+    parseInt(document.getElementById("alert-hours").value) || 0;
+  const newAlerMinutes =
+    parseInt(document.getElementById("alert-minutes").value) || 0;
+  const newAlerSeconds =
+    parseInt(document.getElementById("alert-seconds").value) || 0;
   const newAlertType = document.getElementById("alert-type").value;
   const color = document.getElementById("alert-color").value;
   const sound = document.getElementById("alert-sound").value;
   const selectedClient = document.getElementById("alert-client").value;
 
-  const timeInSeconds = convertToSeconds(hours, minutes, seconds);
+  const newAlertTimeInSeconds = convertToSeconds(
+    newAlertHours,
+    newAlerMinutes,
+    newAlerSeconds
+  );
 
   // Check if user deliberately entered zero (at least one field has a value)
   const hasTimeInput =
     document.getElementById("alert-hours").value !== "" ||
     document.getElementById("alert-minutes").value !== "" ||
     document.getElementById("alert-seconds").value !== "";
-  if (timeInSeconds === 0 && !hasTimeInput) {
+  if (newAlertTimeInSeconds === 0 && !hasTimeInput) {
     alert(
       "Please enter a time for your new alert (set to 0 for an 'overtime' alert."
     );
@@ -28,7 +35,7 @@ export async function addNewAlert(userProfile) {
   const conflictMessage = checkForAlertConflicts(
     userProfile.preferences.alerts,
     newAlertType,
-    timeInSeconds,
+    newAlertTimeInSeconds,
     selectedClient
   );
   if (conflictMessage) {
@@ -72,7 +79,7 @@ export async function addNewAlert(userProfile) {
 
   const newAlert = {
     type: alertTypeToUse,
-    time_in_seconds: timeInSeconds,
+    time_in_seconds: newAlertTimeInSeconds,
     asset_reference: assetReference,
     jobcode_ids: jobcodeIds,
   };
@@ -481,14 +488,14 @@ function alertTypesMatch(storedAlertType, formAlertType) {
  * Checks for conflicting alerts with client-aware logic
  * @param {Array} alerts - Array of existing alerts
  * @param {string} newAlertType - The form alert type (badge, sound, notification)
- * @param {number} timeInSeconds - The alert time in seconds
+ * @param {number} newAlertTimeInSeconds - The alert time in seconds
  * @param {string} selectedClient - The selected client ID (empty string for "All clients")
  * @returns {string|null} - Error message if conflict exists, null if no conflict
  */
 function checkForAlertConflicts(
   alerts,
   newAlertType,
-  timeInSeconds,
+  newAlertTimeInSeconds,
   selectedClient
 ) {
   if (!alerts) return null;
@@ -499,7 +506,7 @@ function checkForAlertConflicts(
   const existingAllClientsAlert = alerts.find(
     (alert) =>
       alertTypesMatch(alert.type, newAlertType) &&
-      alert.time_in_seconds === timeInSeconds &&
+      alert.time_in_seconds === newAlertTimeInSeconds &&
       (!alert.jobcode_ids || alert.jobcode_ids.length === 0)
   );
 
@@ -512,7 +519,7 @@ function checkForAlertConflicts(
     const clashingAlert = alerts.find(
       (alert) =>
         alertTypesMatch(alert.type, newAlertType) &&
-        alert.time_in_seconds === timeInSeconds
+        alert.time_in_seconds === newAlertTimeInSeconds
     );
 
     if (clashingAlert) {
@@ -525,7 +532,7 @@ function checkForAlertConflicts(
     const existingClientSpecificAlert = alerts.find(
       (alert) =>
         alertTypesMatch(alert.type, newAlertType) &&
-        alert.time_in_seconds === timeInSeconds
+        alert.time_in_seconds === newAlertTimeInSeconds
     );
 
     if (existingClientSpecificAlert) {

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -76,7 +76,7 @@ export async function addNewAlert(userProfile) {
 
   // We make this an array in case we want to support multiple clients per alert in future
   const newAlertJobcodeIds = newAlertSelectedClient
-    ? [newAlertSelectedClient]
+    ? [parseInt(newAlertSelectedClient)]
     : [];
 
   const newAlert = {

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -26,7 +26,7 @@ export async function addNewAlert(userProfile) {
     document.getElementById("alert-seconds").value !== "";
   if (newAlertTimeInSeconds === 0 && !hasTimeInput) {
     alert(
-      "Please enter a time for your new alert (set to 0 for an 'overtime' alert."
+      "Please enter a time for your new alert (set to 0 for an 'overtime' alert)."
     );
     return;
   }

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -493,17 +493,17 @@ function alertTypesMatch(storedAlertType, formAlertType) {
  * @returns {string|null} - Error message if conflict exists, null if no conflict
  */
 function checkForAlertConflicts(
-  alerts,
+  existingAlerts,
   newAlertType,
   newAlertTimeInSeconds,
   newAlertSelectedClient
 ) {
-  if (!alerts) return null;
+  if (!existingAlerts) return null;
 
   const isNewAlertForAllClients = !newAlertSelectedClient;
 
   // Check if there's already an "all clients" alert with same type and time
-  const existingAllClientsAlert = alerts.find(
+  const existingAllClientsAlert = existingAlerts.find(
     (alert) =>
       alertTypesMatch(alert.type, newAlertType) &&
       alert.time_in_seconds === newAlertTimeInSeconds &&
@@ -516,7 +516,7 @@ function checkForAlertConflicts(
 
   // If new alert is client-specific, check for any alert of the same type and time
   if (!isNewAlertForAllClients) {
-    const clashingAlert = alerts.find(
+    const clashingAlert = existingAlerts.find(
       (alert) =>
         alertTypesMatch(alert.type, newAlertType) &&
         alert.time_in_seconds === newAlertTimeInSeconds
@@ -527,9 +527,9 @@ function checkForAlertConflicts(
     }
   }
 
-  // If new alert is for all clients, check for any alerts of same type and time
+  // If new alert is for all clients, check for any existingAlerts of same type and time
   if (isNewAlertForAllClients) {
-    const existingClientSpecificAlert = alerts.find(
+    const existingClientSpecificAlert = existingAlerts.find(
       (alert) =>
         alertTypesMatch(alert.type, newAlertType) &&
         alert.time_in_seconds === newAlertTimeInSeconds

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -33,7 +33,7 @@ export async function addNewAlert(userProfile) {
     // Check if there's already an "all clients" alert with same type and time
     const existingAllClientsAlert = alerts.find(
       (alert) =>
-        alert.type === alertType &&
+        alertTypesMatch(alert.type, alertType) &&
         alert.time_in_seconds === timeInSeconds &&
         (!alert.jobcode_ids || alert.jobcode_ids.length === 0)
     );
@@ -45,32 +45,17 @@ export async function addNewAlert(userProfile) {
       return;
     }
 
-    console.log(
-      "No clashing all clients alerts, about to check for clashing client-specific alerts"
-    );
-
     // If new alert is client-specific, check for any alert of the same type and time
     if (!isNewAlertForAllClients) {
-      console.log("New alert is client-specific, checking for clashes");
-
-      console.log("new alert type = ");
-      console.log(alertType);
-      console.log("new alert timeInSeconds = ");
-      console.log(timeInSeconds);
-
-      console.log("alerts about to check = ");
-      console.log(alerts);
-
       const clashingAlert = alerts.find(
         (alert) =>
-          alert.type === alertType && alert.time_in_seconds === timeInSeconds
+          alertTypesMatch(alert.type, alertType) &&
+          alert.time_in_seconds === timeInSeconds
       );
-
-      console.log("Clashing alert check result:", clashingAlert);
 
       if (clashingAlert) {
         alert(
-          `You already have an alert of this type and this time for this client specifically.`
+          `You already have a client-specific alert of this type and this time. Please delete this alert first before adding a new one.`
         );
         return;
       }
@@ -78,10 +63,10 @@ export async function addNewAlert(userProfile) {
 
     // If new alert is for all clients, check for any alerts of same type and time
     if (isNewAlertForAllClients) {
-      console.log("New alert is for all clients, checking for clashes");
       const existingClientSpecificAlert = alerts.find(
         (alert) =>
-          alert.type === alertType && alert.time_in_seconds === timeInSeconds
+          alertTypesMatch(alert.type, alertType) &&
+          alert.time_in_seconds === timeInSeconds
       );
 
       if (existingClientSpecificAlert) {
@@ -528,4 +513,15 @@ export function initializeAlertTypeSelector() {
       placeholderContainer.style.display = "block";
     }
   });
+}
+
+// Helper function to check if alert types match
+function alertTypesMatch(storedAlertType, formAlertType) {
+  // For sound alerts, stored type could be 'sound_default' or 'sound_custom'
+  // but form type is just 'sound'
+  if (formAlertType === "sound") {
+    return storedAlertType.includes("sound");
+  }
+  // For other types (badge, notification), they should match exactly
+  return storedAlertType === formAlertType;
 }

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -17,7 +17,6 @@ export async function addNewAlert(userProfile) {
     document.getElementById("alert-hours").value !== "" ||
     document.getElementById("alert-minutes").value !== "" ||
     document.getElementById("alert-seconds").value !== "";
-
   if (timeInSeconds === 0 && !hasTimeInput) {
     alert(
       "Please enter a time for your new alert (set to 0 for an 'overtime' alert."
@@ -32,7 +31,6 @@ export async function addNewAlert(userProfile) {
     timeInSeconds,
     selectedClient
   );
-
   if (conflictMessage) {
     alert(conflictMessage);
     return;

--- a/popup/alerts.js
+++ b/popup/alerts.js
@@ -32,7 +32,7 @@ export async function addNewAlert(userProfile) {
     timeInSeconds,
     selectedClient
   );
-  
+
   if (conflictMessage) {
     alert(conflictMessage);
     return;
@@ -66,13 +66,6 @@ export async function addNewAlert(userProfile) {
         console.error("Error getting custom sound name:", error);
         displayName = soundParts[1];
       }
-    } else {
-      // Legacy support - assume it's a default sound
-      alertTypeToUse = "sound_default";
-      assetReference = sound;
-      displayName = sound
-        .replace(/_/g, " ")
-        .replace(/\b\w/g, (l) => l.toUpperCase());
     }
   }
 
@@ -494,9 +487,14 @@ function alertTypesMatch(storedAlertType, formAlertType) {
  * @param {string} selectedClient - The selected client ID (empty string for "All clients")
  * @returns {string|null} - Error message if conflict exists, null if no conflict
  */
-function checkForAlertConflicts(alerts, alertType, timeInSeconds, selectedClient) {
+function checkForAlertConflicts(
+  alerts,
+  alertType,
+  timeInSeconds,
+  selectedClient
+) {
   if (!alerts) return null;
-  
+
   const isNewAlertForAllClients = !selectedClient;
 
   // Check if there's already an "all clients" alert with same type and time

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -188,14 +188,6 @@
                                 placeholder="S" min="0" max="59">
                         </div>
 
-                        <!-- Overtime Checkbox -->
-                        <div class="flex items-center">
-                            <label class="flex items-center gap-2">
-                                <input type="checkbox" id="overtime-alert" class="form-checkbox h-4 w-4 text-blue-600">
-                                <span class="text-sm text-gray-600 dark:text-gray-300"
-                                    id="overtime-text">Overtime</span>
-                            </label>
-                        </div>
                     </div>
 
                     <!-- Add Alert Button -->

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -188,11 +188,20 @@
                                 placeholder="S" min="0" max="59">
                         </div>
 
+                        <!-- Client/Jobcode Selector -->
+                        <div class="flex items-center">
+                            <select id="alert-client"
+                                class="border border-gray-300 dark:border-gray-600 rounded-md p-1 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-white w-24">
+                                <option value="">All clients</option>
+                                <!-- Client options will be populated dynamically -->
+                            </select>
+                        </div>
+
                     </div>
 
                     <!-- Add Alert Button -->
                     <button id="add-alert"
-                        class="bg-blue-600 text-white px-4 py-1 rounded-md hover:bg-blue-700 text-sm">
+                        class="bg-blue-600 text-white px-3 py-1 rounded-md hover:bg-blue-700 text-sm">
                         Add Alert
                     </button>
                 </div>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -21,6 +21,7 @@ import {
   addNewAlert,
   populateAlerts,
   initializeAlertTypeSelector,
+  populateClientSelector,
 } from "/popup/alerts.js";
 import { initializeAudioUpload } from "/popup/audioUpload.js";
 import { getCurrentDate, isDateInCurrentMonth } from "/shared/dateUtils.js";
@@ -174,6 +175,7 @@ async function updateUIWithUserProfile(userProfile) {
 
 
   populateAlerts(userProfile);
+  populateClientSelector(userProfile);
 
   renderAllClientsTable(userProfile);
 }

--- a/popup/styles.css
+++ b/popup/styles.css
@@ -990,11 +990,6 @@ video {
   background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
 }
 
-.bg-purple-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(147 51 234 / var(--tw-bg-opacity, 1));
-}
-
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
@@ -1295,11 +1290,6 @@ video {
 .hover\:bg-green-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(21 128 61 / var(--tw-bg-opacity, 1));
-}
-
-.hover\:bg-purple-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(126 34 206 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:text-black:hover {


### PR DESCRIPTION
- Description
    Add client-specific feature to alerts. E.g., have an audio alert when you're down to 4 hours left on Client A, but only a badge or nothing at all when you're down to 4 hours while working on Clients B, C, D, and E.
    *This is possible: add the client id to the alerts in local storage; user has to specify an existing client when creating an alert; adjust the code that checks whether to action sound/badge/notification alerts to take into account the active client id.*
    
- Steps
    - [x]  *user has to specify an existing client (or all clients) when creating an alert*
        - [x]  Validation logic to prevent duplicate alerts adding
    - [x]  *add the client id to the alerts in local storage -* store jobcode_id on alert creation
    - [x]  *adjust the code that checks whether to action sound/badge/notification alerts to take into account the active client id.*
        - [x]  Pass currentlyActiveJobcodeId into startBackgroundCountdown()
        - [x]  For each of the alert checks, pass in the currentlyActiveJobcodeId and only trigger if the alert.jobcodeId matches it